### PR TITLE
Handle job state COMPLETING as still running

### DIFF
--- a/slurm-clusercockpit-sync.py
+++ b/slurm-clusercockpit-sync.py
@@ -119,7 +119,7 @@ class SlurmSync:
     def _jobRunning(self, jobid):
         for job in self.slurmJobData['jobs']:
             if int(job['job_id']) == int(jobid):
-                if job['job_state'] == 'RUNNING':
+                if job['job_state'] in ['RUNNING', 'COMPLETING']:
                     return True
         return False
 


### PR DESCRIPTION
Currently, jobs in the COMPLETING state are not classified as running jobs:
https://github.com/pc2/cc-slurm-sync/blob/97bde1db82da99acc7dfb26440512284656b7d92/slurm-clusercockpit-sync.py#L119-L124

So, they will be stopped in ClusterCockpit and will be marked as failed, as that state is none of the final states:
https://github.com/pc2/cc-slurm-sync/blob/97bde1db82da99acc7dfb26440512284656b7d92/slurm-clusercockpit-sync.py#L293-L294

https://github.com/pc2/cc-slurm-sync/blob/97bde1db82da99acc7dfb26440512284656b7d92/slurm-clusercockpit-sync.py#L312-L313

To fix this, handle jobs in the state COMPLETING as still running.