### PR TITLE
Diff node config

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -131,10 +131,6 @@ This option is unique to every cluster system. This regex describes the sytax of
 
 Example: `^(n2(lcn|cn|fpga|gpu)[\\d{2,4}\\,\\-\\[\\]]+)+$`
 
-**nodes**
-
-The "cores_per_socket" value is used within the transformation of the slurm data to ClusterCockpit data structure. CC uses rising ids to identify each core. Slurm seperates the cores by socket. So the scipts needs to know, how many cores per socket are available to calculate the cc representation of the allocated resources. 
-
 ## Running the script
 
 Simply run `slurm-clusercockpit-sync.py` inside the same directory which contains the config.json file. A brief help is also available:

--- a/config.json.example
+++ b/config.json.example
@@ -28,9 +28,5 @@
 			"7": "00000000:BD:00.0"
 		}
 	},
-	"node_regex" : "^(n2(lcn|cn|fpga|gpu)[\\d{2,4}\\,\\-\\[\\]]+)+$",
-	"nodes" : {
-		"sockets" : 2,
-		"cores_per_socket" : 64
-	}
+	"node_regex" : "^(n2(lcn|cn|fpga|gpu)[\\d{2,4}\\,\\-\\[\\]]+)+$"
 }

--- a/slurm-clusercockpit-sync.py
+++ b/slurm-clusercockpit-sync.py
@@ -178,14 +178,15 @@ class SlurmSync:
         nodelist = self._convertNodelist(job['job_resources']['nodes'])
 
         # Exclusive job?
-        if job['exclusive'][0] == "true":
-            exclusive = 1
-        # exclusive to user
-        elif job['exclusive'][0] == "user":
-            exclusive = 2
-        # exclusive to mcs
-        elif job['exclusive'][0] == "mcs":
-            exclusive = 3
+        if len(job['exclusive']) > 0:
+            if job['exclusive'][0] == "true":
+                exclusive = 1
+            # exclusive to user
+            elif job['exclusive'][0] == "user":
+                exclusive = 2
+            # exclusive to mcs
+            elif job['exclusive'][0] == "mcs":
+                exclusive = 3
         # default is shared node
         else:
             exclusive = 0

--- a/slurm-clusercockpit-sync.py
+++ b/slurm-clusercockpit-sync.py
@@ -178,13 +178,13 @@ class SlurmSync:
         nodelist = self._convertNodelist(job['job_resources']['nodes'])
 
         # Exclusive job?
-        if job['shared'] == "none":
+        if job['exclusive'][0] == "true":
             exclusive = 1
         # exclusive to user
-        elif job['shared'] == "user":
+        elif job['exclusive'][0] == "user":
             exclusive = 2
         # exclusive to mcs
-        elif job['shared'] == "mcs":
+        elif job['exclusive'][0] == "mcs":
             exclusive = 3
         # default is shared node
         else:
@@ -256,11 +256,12 @@ class SlurmSync:
                 if i < len(allocations):
                     alloc = allocations[i]  # Hole die aktuelle Zuweisung
                     sockets = alloc.get('sockets', [])  # Hole Sockets aus der aktuellen Zuweisung
+                    numcores = len(sockets[0]['cores'])
                     hwthreads = []
                     for socket in sockets:
                         for core in socket.get('cores', []):
                             if 'ALLOCATED' in core.get('status', []):  # Prüfe den Status
-                                hwthreads.append(core['index'])  # Index hinzufügen
+                                hwthreads.append(core['index'] + socket['index'] * numcores)  # Index hinzufügen
                     resources.update({"hwthreads": hwthreads})
                 else:
                     print(f"Warning: Index {i} out of range for node allocations")


### PR DESCRIPTION
Eliminate node config in config file. Gather needed information from the squeue output instead. Requires Slurm 24.05. 